### PR TITLE
Assume that iconv is not required if it is not available.

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
On Arch and Ubuntu 16, attempting to link against iconv fails and does not seem to be required. This fix could be improved somewhat, for example by using the stem of the temp file name rather than "aksdfjhawkdjlfhkasdjhfkljasdhfkjahsdf", but isn't too bad for a total freebie, I hope.
